### PR TITLE
Add TypeScript interfaces for user authentication and group management

### DIFF
--- a/nextjs/types/pocketbase.ts
+++ b/nextjs/types/pocketbase.ts
@@ -1,0 +1,86 @@
+export interface BaseRecord {
+    id: string;
+    created: string;
+    updated: string;
+}
+
+export interface SuperUser extends BaseRecord {
+    password: string;
+    tokenKey: string;
+    email: string;
+    emailVisibility: boolean;
+    verified: boolean;
+}
+
+export interface User extends BaseRecord {
+    password: string;
+    tokenKey: string;
+    email: string;
+    emailVisibility: boolean;
+    verified: boolean;
+    display_name: string;
+}
+
+export interface AuthOrigin extends BaseRecord {
+    collectionRef: string;
+    recordRef: string;
+    fingerprint: string;
+}
+
+export interface ExternalAuth extends BaseRecord {
+    collectionRef: string;
+    recordRef: string;
+    provider: string;
+    providerId: string;
+}
+
+export interface MFA extends BaseRecord {
+    collectionRef: string;
+    recordRef: string;
+    method: string;
+}
+
+export interface OTP extends BaseRecord {
+    collectionRef: string;
+    recordRef: string;
+    password: string;
+    sentTo?: string;
+}
+
+export interface GroupMember extends BaseRecord {
+    user_id: string;
+    group_id: string;
+    role?: "admin" | "contributer";
+    joined_at: string;
+}
+
+export interface Group extends BaseRecord {
+    created_by: string;
+    name: string;
+    description?: string;
+}
+
+export interface InviteLink extends BaseRecord {
+    group_id: string;
+    created_by: string;
+    max_uses?: number;
+    uses?: number;
+    infinite?: boolean;
+}
+
+export interface Survey extends BaseRecord {
+    created_by: string;
+    created_in: string;
+    type: "majority" | "score" | "consensus";
+    title: string;
+    description?: string;
+    start_at: string;
+    end_at: string;
+}
+
+export interface Vote extends BaseRecord {
+    user_id: string;
+    survey_id: string;
+    pro?: boolean;
+    voted_at: string;
+}


### PR DESCRIPTION
This pull request introduces several new TypeScript interfaces in the `nextjs/types/pocketbase.ts` file to define the structure of various records used in the application. These interfaces extend a common `BaseRecord` interface.

The most important changes include:

* Added `BaseRecord` interface to define common fields for all records.
* Added `SuperUser` and `User` interfaces to represent user data with fields for authentication and profile information.
* Added `AuthOrigin` and `ExternalAuth` interfaces to manage authentication sources and external authentication providers.
* Added `GroupMember` and `Group` interfaces to define group membership and group details.
* Added `Survey` and `Vote` interfaces to handle survey creation and voting records.