### PR TITLE
Swipeer 19 pocketbase types anstelle von interfaces verwenden

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       - /app/node_modules
     depends_on:
       - pocketbase
+    env_file:
+      - ./nextjs/.env
 
   pocketbase:
     image: ghcr.io/muchobien/pocketbase:latest

--- a/nextjs/app/api/invites/group-info/route.ts
+++ b/nextjs/app/api/invites/group-info/route.ts
@@ -1,15 +1,10 @@
 //api/invites/group-info
 import { NextRequest, NextResponse } from 'next/server';
 import pb from '@/lib/admin-pocketbase';
+import { GroupsRecord } from '@/types/pocketbase-types';
 
-interface AdvancedGroupRecord {
-    id: string;
-    created_by: string;
-    name: string;
-    description: string;
+interface AdvancedGroupRecord extends GroupsRecord {
     member_count: number;
-    created: string;
-    updated: string;
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -31,13 +26,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         }).then(res => res.totalItems);
 
         const groupRecord: AdvancedGroupRecord = {
-            id: group.id,
-            created_by: group.created_by,
-            name: group.name,
-            description: group.description,
+            ...group,
             member_count: member_count,
-            created: group.created,
-            updated: group.updated,
         };
 
         return new NextResponse(JSON.stringify(groupRecord), {

--- a/nextjs/app/group/[groupId]/page.tsx
+++ b/nextjs/app/group/[groupId]/page.tsx
@@ -5,9 +5,10 @@ import { useRouter } from 'next/navigation';
 import '@/styles/globals.css';
 import InviteLinkModal from './components/InviteLinkModal';
 import LeaveGroupModal from './components/LeaveGroupModal';
+import { UsersRecord, GroupMembersRecord, GroupsRecord, SurveysRecord, InviteLinksRecord, GroupMembersRoleOptions} from '@/types/pocketbase-types';
 
 const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
-  const [group, setGroup] = useState<Group | null>(null);
+  const [group, setGroup] = useState<GroupsRecord | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [groupId, setGroupId] = useState<string | null>(null);
@@ -17,7 +18,8 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
   const [showModal, setShowModal] = useState(false);
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [surveys, setSurveys] = useState<SurveyWithCreator[]>([]);
+  const [surveys, setSurveys] = useState<(SurveysRecord & { creator_name: string })[]>([]);
+  const [membersWithDisplayName, setMembersWithDisplayName] = useState<(GroupMembersRecord & { display_name: string })[]>([]);
   const router = useRouter();
 
   useEffect(() => {
@@ -34,66 +36,42 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
 
     const fetchGroup = async () => {
       try {
-        const group = await pb.collection('groups').getOne(groupId);
-        const members = await pb.collection('group_members').getFullList({
+        const group = await pb.collection('groups').getOne<GroupsRecord>(groupId);
+        const members = await pb.collection('group_members').getFullList<GroupMembersRecord>({
           filter: `group_id = "${groupId}"`
         });
 
-        const userPromises = members.map((member) => pb.collection('users').getOne(member.user_id));
+        const userPromises = members.map((member) => pb.collection('users').getOne<UsersRecord>(member.user_id));
 
         const users = await Promise.all(userPromises);
 
-        members.forEach((member, index) => {
-          member.display_name = users[index].display_name;
-          member.role = member.role.charAt(0).toUpperCase() + member.role.slice(1);
-        });
+        const membersWithDisplayName = members.map((member, index) => ({
+          ...member,
+          display_name: users[index].display_name,
+          role: member.role as GroupMembersRoleOptions,
+        }));
 
-        members.sort((a, b) => new Date(a.joined_at).getTime() - new Date(b.joined_at).getTime());
-
+        membersWithDisplayName.sort((a, b) => new Date(a.joined_at ?? 0).getTime() - new Date(b.joined_at ?? 0).getTime());
         console.log('Group:', group);
-        console.log('Members:', members);
+        console.log('Members:', membersWithDisplayName);
 
-        setGroup({
-          id: group.id,
-          created_by: group.created_by,
-          members: members.map((member) => ({
-            id: member.id,
-            display_name: member.display_name,
-            role: member.role,
-            email: member.email,
-            created: member.created,
-            updated: member.updated,
-            joined_at: member.joined_at,
-          })) as User[],
-          name: group.name,
-          description: group.description,
-          created: group.created,
-          updated: group.updated,
-        });
+        setGroup(group);
+        setMembersWithDisplayName(membersWithDisplayName);
 
-        const user = pb.authStore.model;
+        const user = pb.authStore.model as UsersRecord;
         if (user) {
-          const isAdmin = members.some(member => member.user_id === user.id && member.role.toLowerCase() === 'admin');
+          const isAdmin = membersWithDisplayName.some(member => member.user_id === user.id && member.role.toLowerCase() === 'admin');
           setIsAdmin(isAdmin);
         }
 
-        const surveys = await pb.collection('surveys').getFullList({
+        const surveys = await pb.collection('surveys').getFullList<SurveysRecord>({
           filter: `created_in = "${groupId}"`
         });
 
-        const surveyCreators = await Promise.all(surveys.map(survey => pb.collection('users').getOne(survey.created_by)));
+        const surveyCreators = await Promise.all(surveys.map(survey => pb.collection('users').getOne<UsersRecord>(survey.created_by)));
 
         setSurveys(surveys.map((survey, index) => ({
-          id: survey.id,
-          created: survey.created,
-          updated: survey.updated,
-          created_by: survey.created_by,
-          created_in: survey.created_in,
-          type: survey.type,
-          title: survey.title,
-          description: survey.description,
-          start_at: survey.start_at,
-          end_at: survey.end_at,
+          ...survey,
           creator_name: surveyCreators[index].display_name,
         })));
 
@@ -113,7 +91,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
 
   const handleLeaveGroup = async () => {
     try {
-      const user = pb.authStore.model;
+      const user = pb.authStore.model as UsersRecord;
       if (!user) {
         setLeaveGroupError('You are not logged in. Please log in and try again.');
         return;
@@ -121,7 +99,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
 
       if (!group) return;
 
-      const groupMembersRecord = await pb.collection('group_members').getFullList({
+      const groupMembersRecord = await pb.collection('group_members').getFullList<GroupMembersRecord>({
         filter: `group_id = "${groupId}"`
       });
 
@@ -147,7 +125,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
         } else {
           const newAdmin = groupMembersRecord
             .filter(member => member.user_id !== user.id)
-            .sort((a, b) => new Date(a.joined_at).getTime() - new Date(b.joined_at).getTime())[0];
+            .sort((a, b) => new Date(a.joined_at ?? 0).getTime() - new Date(b.joined_at ?? 0).getTime())[0];
 
           if (newAdmin) {
             await pb.collection('group_members').update(newAdmin.id, { role: 'admin' });
@@ -170,7 +148,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
 
   const handleGenerateInviteLink = async (isUnlimited: boolean) => {
     try {
-      const user = pb.authStore.model;
+      const user = pb.authStore.model as UsersRecord;
       if (!user) {
         throw new Error('You are not logged in. Please log in and try again.');
       }
@@ -179,7 +157,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
         throw new Error('Group ID is missing.');
       }
 
-      await pb.collection('invite_links').create({
+      await pb.collection('invite_links').create<InviteLinksRecord>({
         group_id: groupId,
         created_by: user.id,
         max_uses: isUnlimited ? null : maxUses ?? 1,
@@ -241,11 +219,11 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
       {/* Members List */}
       <h2 className="text-2xl font-semibold mb-4 text-[var(--primary-color)]">Members</h2>
       <ul className="list-none pl-0">
-        {group?.members.map((member) => (
+        {membersWithDisplayName.map((member) => (
           <li key={member.id} className="mb-4 flex items-center bg-gray-100 p-4 rounded-lg auto-shadow">
             <p className="text-gray-800 font-medium flex-1">{member.display_name}</p>
             <p className="text-gray-500 text-sm flex-1 text-center">
-              Member since {calculateMemberSince(member.joined_at)} {calculateMemberSince(member.joined_at) === 1 ? 'day' : 'days'}
+              Member since {member.joined_at ? calculateMemberSince(member.joined_at) : 'N/A'} {member.joined_at && calculateMemberSince(member.joined_at) === 1 ? 'day' : 'days'}
             </p>
             <span className="text-gray-600 flex-1 text-right">{member.role}</span>
           </li>
@@ -303,44 +281,7 @@ const GroupPage = ({ params }: { params: Promise<{ groupId: string }> }) => {
         />
       )}
     </div>
-  );  
+  );
 };
 
 export default GroupPage;
-
-interface Group {
-  id: string;
-  created_by: string;
-  members: User[];
-  name: string;
-  description: string;
-  created: string;
-  updated: string;
-}
-
-interface User {
-  id: string;
-  email: string;
-  display_name: string;
-  role: string;
-  created: string;
-  updated: string;
-  joined_at: string;
-}
-
-interface Survey {
-  id: string;
-  created: string;
-  updated: string;
-  created_by: string;
-  created_in: string;
-  type: string;
-  title: string;
-  description: string;
-  start_at: string;
-  end_at: string;
-}
-
-interface SurveyWithCreator extends Survey {
-  creator_name: string;
-}

--- a/nextjs/app/invite/[id]/page.tsx
+++ b/nextjs/app/invite/[id]/page.tsx
@@ -3,19 +3,8 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState, useRef } from 'react';
 import pb from '@/lib/pocketbase';
+import { InviteLinksRecord } from '@/types/pocketbase-types';
 
-interface InviteRecord {
-    collectionId: string;
-    collectionName: string;
-    id: string;
-    group_id: string;
-    created_by: string;
-    max_uses: number;
-    uses: number;
-    infinite: boolean;
-    created: string;
-    updated: string;
-}
 
 interface GroupInfo {
     name: string;
@@ -27,7 +16,7 @@ const InvitePage: React.FC = () => {
     const params = useParams();
     const router = useRouter();
     const id = Array.isArray(params?.id) ? params.id[0] : params?.id;
-    const [invite, setInvite] = useState<InviteRecord | null>(null);
+    const [invite, setInvite] = useState<InviteLinksRecord | null>(null);
     const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [showDialog, setShowDialog] = useState(false);
@@ -38,28 +27,16 @@ const InvitePage: React.FC = () => {
         const fetchInvite = async () => {
             if (id && !hasFetched.current) {
                 try {
-                    const record = await pb.collection('invite_links').getOne(id);
-                    if (record.uses >= record.max_uses) {
+                    const inviteRecord = await pb.collection('invite_links').getOne(id);
+                    if (inviteRecord.uses >= inviteRecord.max_uses) {
                         setError('This invite has been used too many times.');
                         setLoading(false);
                         return;
                     }
-                    const inviteRecord: InviteRecord = {
-                        collectionId: record.collectionId,
-                        collectionName: record.collectionName,
-                        id: record.id,
-                        group_id: record.group_id,
-                        created_by: record.created_by,
-                        max_uses: record.max_uses,
-                        uses: record.uses,
-                        infinite: record.infinite,
-                        created: record.created,
-                        updated: record.updated,
-                    };
                     setInvite(inviteRecord);
                     hasFetched.current = true;
 
-                    const response = await fetch(`/api/invites/group-info?group_id=${record.group_id}`);
+                    const response = await fetch(`/api/invites/group-info?group_id=${inviteRecord.group_id}`);
                     if (!response.ok) {
                         throw new Error('Failed to fetch group info');
                     }

--- a/nextjs/components/GroupList.tsx
+++ b/nextjs/components/GroupList.tsx
@@ -1,13 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import pb from '@/lib/pocketbase';
-
-interface Group {
-  id: string;
-  name: string;
-}
+import { GroupsRecord } from '@/types/pocketbase-types';
 
 const GroupList: React.FC = () => {
-  const [groups, setGroups] = useState<Group[]>([]);
+  const [groups, setGroups] = useState<GroupsRecord[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/nextjs/components/GroupSidebar.tsx
+++ b/nextjs/components/GroupSidebar.tsx
@@ -1,15 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import pb from '@/lib/pocketbase';
 import Link from 'next/link';
-
-interface Group {
-  id: string;
-  name: string;
-  description: string;
-}
+import { GroupsRecord } from '@/types/pocketbase-types';
 
 const GroupSidebar: React.FC = () => {
-  const [groups, setGroups] = useState<Group[]>([]);
+  const [groups, setGroups] = useState<GroupsRecord[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -24,7 +24,6 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "cross-env": "^7.0.3",
         "dotenv-cli": "^8.0.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.14",
@@ -2022,25 +2021,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "optional": true
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -5273,6 +5253,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
       "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -11,6 +11,7 @@
         "@react-spring/web": "^9.7.5",
         "@use-gesture/react": "^10.3.1",
         "autoprefixer": "^10.4.20",
+        "cross-env": "^7.0.3",
         "dotenv": "^16.4.7",
         "next": "^15.1.6",
         "pocketbase": "^0.21.5",
@@ -2022,6 +2023,24 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "optional": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -2034,7 +2053,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4130,8 +4148,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -5149,7 +5166,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5908,7 +5924,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5920,7 +5935,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6823,7 +6837,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "cross-env": "^7.0.3",
         "dotenv-cli": "^8.0.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.14",
@@ -2021,6 +2022,25 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "optional": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -5253,7 +5273,6 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
       "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "cross-env": "^7.0.3",
         "dotenv-cli": "^8.0.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.14",
@@ -2021,6 +2022,24 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "optional": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -24,7 +24,6 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "cross-env": "^7.0.3",
         "dotenv-cli": "^8.0.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.14",
@@ -2022,24 +2021,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "optional": true
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -5272,7 +5253,6 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
       "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "gen:types": "cross-env POCKETBASE_URL=$POCKETBASE_URL ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD && npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
+    "_gen:types": "pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out types/pocketbase-types.ts",
+    "gen:types": "dotenv -e .env -- npm run _gen:types",
     "dev": "npm run gen:types && next dev",
     "build": "next build",
     "start": "next start",
@@ -26,7 +27,6 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "cross-env": "^7.0.3",
     "dotenv-cli": "^8.0.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.14",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "gen:types": "npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
+    "gen:types": "cross-env POCKETBASE_URL=$POCKETBASE_URL ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD && npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
     "dev": "npm run gen:types && next dev",
     "build": "next build",
     "start": "next start",
@@ -26,6 +26,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "cross-env": "^7.0.3",
     "dotenv-cli": "^8.0.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.14",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "gen:types": "cross-env POCKETBASE_URL=$POCKETBASE_URL ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
+    "gen:types": "npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
     "dev": "npm run gen:types && next dev",
     "build": "next build",
     "start": "next start",
@@ -31,7 +31,6 @@
     "eslint-config-next": "14.2.14",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5",
-    "cross-env": "^7.0.3"
+    "typescript": "^5"
   }
 }

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "gen:types": "set -o allexport && source /app/.env && set +o allexport && npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
+    "gen:types": "cross-env POCKETBASE_URL=$POCKETBASE_URL ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD npx pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out /app/types/pocketbase-types.ts",
     "dev": "npm run gen:types && next dev",
     "build": "next build",
     "start": "next start",
@@ -31,6 +31,7 @@
     "eslint-config-next": "14.2.14",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "cross-env": "^7.0.3"
   }
 }

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "_gen:types": "pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out types/pocketbase-types.ts",
+    "_gen:types": "cross-env-shell \"pocketbase-typegen --url $POCKETBASE_URL --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --out types/pocketbase-types.ts\"",
     "gen:types": "dotenv -e .env -- npm run _gen:types",
     "dev": "npm run gen:types && next dev",
     "build": "next build",
@@ -14,6 +14,7 @@
     "@react-spring/web": "^9.7.5",
     "@use-gesture/react": "^10.3.1",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "next": "^15.1.6",
     "pocketbase": "^0.21.5",

--- a/nextjs/types/pocketbase-types.ts
+++ b/nextjs/types/pocketbase-types.ts
@@ -131,7 +131,7 @@ export enum SurveysTypeOptions {
 export type SurveysRecord = {
 	created?: IsoDateString
 	created_by: RecordIdString
-	created_in?: RecordIdString
+	created_in: RecordIdString
 	description?: string
 	end_at: IsoDateString
 	id: string


### PR DESCRIPTION
This pull request includes several updates to the `nextjs/app/group/[groupId]/page.tsx` file to improve type safety and code maintainability, as well as the addition of the `cross-env` package to the project.

Type safety and code maintainability improvements:

* Updated state types for `group`, `surveys`, and `membersWithDisplayName` to use specific record types from `pocketbase-types`. ([nextjs/app/group/[groupId]/page.tsxR8-R11](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceR8-R11), [nextjs/app/group/[groupId]/page.tsxL20-R22](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL20-R22))
* Modified API calls to include type parameters, ensuring the correct types are used for the responses. ([nextjs/app/group/[groupId]/page.tsxL37-R74](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL37-R74), [nextjs/app/group/[groupId]/page.tsxL116-R102](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL116-R102), [nextjs/app/group/[groupId]/page.tsxL150-R128](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL150-R128), [nextjs/app/group/[groupId]/page.tsxL173-R151](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL173-R151), [nextjs/app/group/[groupId]/page.tsxL182-R160](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL182-R160))
* Removed redundant interfaces (`Group`, `User`, `Survey`, `SurveyWithCreator`) from the file. ([nextjs/app/group/[groupId]/page.tsxL310-L346](diffhunk://#diff-f2aea29324b2ee40679fc0806cde5bd9a2ce4217f22f9502dcce4dda2d08a0ceL310-L346))

Package updates:

* Added `cross-env` to the `devDependencies` in `package.json` and `package-lock.json` to ensure environment variables are correctly set across different operating systems. [[1]](diffhunk://#diff-017d63237b2c4a55f9f7d67fe1585dedf03576e13702484ccea7fed3b4f2d382R27) [[2]](diffhunk://#diff-017d63237b2c4a55f9f7d67fe1585dedf03576e13702484ccea7fed3b4f2d382R2026-R2044) [[3]](diffhunk://#diff-e1b370919ad70d7d664a73520654fcc1e9d9f87ec208f2c1517a1e2d18ba1c8eL6-R6) [[4]](diffhunk://#diff-e1b370919ad70d7d664a73520654fcc1e9d9f87ec208f2c1517a1e2d18ba1c8eL34-R35)